### PR TITLE
adding trainspawners and traindespawners

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -253,6 +253,11 @@
 		C.operating = position
 		C.update_move_direction()
 
+	// <trainstation13>
+	for(var/obj/effect/trainspawner/TR in trainspawners)
+		TR.operating = position != 0 ? TRUE : FALSE
+	// </trainstation13>
+
 // attack with hand, switch position
 /obj/machinery/conveyor_switch/attack_hand(mob/user)
 	. = ..()

--- a/trainstation13/code/trainspawners.dm
+++ b/trainstation13/code/trainspawners.dm
@@ -58,3 +58,102 @@
 	icon = 'trainstation13/icons/trainstructures.dmi'
 	icon_state = "bear_vodka"
 	anchored = FALSE
+
+/obj/machinery/conveyor_switch
+	var/list/trainspawners
+
+/obj/machinery/conveyor_switch/atom_init_late()
+	..()
+	trainspawners = list()
+	for(var/obj/effect/trainspawner/TR in global.trainspawners)
+		if(TR.id == id)
+			trainspawners += TR
+
+
+var/global/list/trainspawners = list()
+ADD_TO_GLOBAL_LIST(/obj/effect/trainspawner, trainspawners)
+
+/obj/effect/trainspawner
+	name = "spawner mark"
+	icon = 'icons/hud/screen1.dmi'
+	icon_state = "x2"
+	anchored = TRUE
+	layer = TURF_LAYER
+	plane = GAME_PLANE
+	unacidable = TRUE
+	invisibility = INVISIBILITY_ABSTRACT
+
+	// Which conveyor id this trainspawner is linked to.
+	var/id
+
+	var/operating = FALSE
+
+	var/current_spawn_list_type = "normal"
+
+	var/list/spawn_lists = list(
+		"normal" = list(
+			// trees grass and stuff, example below
+			// /obj/tree = 100,
+			// /obj/grass = 90,
+			// /mob/bear = 10,
+			// /mob/easteregg = 1,
+			/obj/item/trash/raisins = 1,
+		),
+		"station" = list(
+			// benches and stuff
+			// /obj/bench = 100,
+			// /obj/trash = 10,
+			// /mob/easteregg = 1,
+			/obj/item/trash/chips = 1,
+		),
+	)
+
+	var/min_delay = 5 SECONDS
+	var/max_delay = 10 SECONDS
+
+	var/next_spawn = 0
+
+/obj/effect/trainspawner/atom_init()
+	. = ..()
+	START_PROCESSING(SSobj, src)
+
+/obj/effect/trainspawner/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/effect/trainspawner/process()
+	if(!operating)
+		return
+	if(next_spawn > world.time)
+		return
+	next_spawn = world.time + rand(min_delay, max_delay)
+
+	var/list/current_spawn_list = spawn_lists[current_spawn_list_type]
+	var/spawn_type = pickweight(current_spawn_list)
+	new spawn_type(loc)
+
+/obj/effect/traindespawner
+	name = "despawner mark"
+	icon = 'icons/hud/screen1.dmi'
+	icon_state = "x"
+	anchored = TRUE
+	layer = TURF_LAYER
+	plane = GAME_PLANE
+	unacidable = TRUE
+	invisibility = INVISIBILITY_ABSTRACT
+
+	var/list/despawn_list = list(
+		// /obj/bench,
+		// /obj/trash,
+		/obj/item/trash/raisins,
+		/obj/item/trash/chips,
+	)
+
+/obj/effect/traindespawner/atom_init()
+	. = ..()
+	despawn_list = typecacheof(despawn_list, FALSE)
+
+/obj/effect/traindespawner/Crossed(atom/movable/AM)
+	. = ..()
+	if(is_type_in_typecache(AM, despawn_list))
+		qdel(AM)


### PR DESCRIPTION
## Описание изменений

добавляет trainspawner:
- имеет несколько списков предметов для спавна с шансами. выбор списка происходит через значение current_spawn_list_type
- подключается к конвеерным переключателям при совпадающем id
- имеет настраиваемую частоту спавна

добавляет traindespawner:
- удаляет предмет типа или подтипа из своего списка
- список не редактируемый админами в угоду оптимизации. можно сделать чтобы админы могли добавлять свои типы в список, но тогда перформанс будет хуже.

