### PR TITLE
admin switches for spawners and despawners

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -336,6 +336,10 @@ var/global/list/admin_verbs_hideable = list(
 			verbs += admin_verbs_whitelist
 		if(holder.rights & R_EVENT)
 			verbs += admin_verbs_event
+		// <trainstation13>
+		if(holder.rights & R_EVENT)
+			verbs += global.admin_verbs_trainstation_event
+		// </trainstation13>
 		if(holder.rights & R_LOG)
 			verbs += admin_verbs_log
 		if(holder.rights & R_VAREDIT)

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -2464,6 +2464,7 @@
 #include "trainstation13\code\trainareas.dm"
 #include "trainstation13\code\trainitems.dm"
 #include "trainstation13\code\trainspawners.dm"
+#include "trainstation13\code\trainstation.dm"
 #include "trainstation13\code\trainstructures.dm"
 #include "trainstation13\code\trainturf.dm"
 #include "trainstation13\maps\trainstation13.dmm"

--- a/trainstation13/code/trainstation.dm
+++ b/trainstation13/code/trainstation.dm
@@ -57,11 +57,15 @@ var/list/train_block = list()
 
 //Admin verb toggles
 
-var/list/event_verbs = list(/client/proc/toggle_block)
+var/list/admin_verbs_trainstation_event = list(
+	/client/proc/toggle_trainstation_block,
+	/client/proc/toggle_train_spawners_and_despawners,
+	/client/proc/change_global_spawn_list_type,
+)
 
 //1 - nothing, 2 - objects, 3 - all
 
-/client/proc/toggle_block()
+/client/proc/toggle_trainstation_block()
 	set category = "Event"
 	set name = "Toggle Invisible Wall"
 


### PR DESCRIPTION
## Описание изменений

добавляет две кнопки для админов:
- "Toggle Spawners and Despawners": полностью выключает спавнеры и деспавнеры во всём мире
- "Change Spawn List Type": меняет у всех спавнеров в мире тип спавнлиста

Так же добавил возможность указывать "null" с шансом выпадения в спавн листе, то есть можно указать что какой-то процент времени спавниться будет ничего.

